### PR TITLE
Editable table refactor 

### DIFF
--- a/src/lib/components/Table/EditableTable.jsx
+++ b/src/lib/components/Table/EditableTable.jsx
@@ -8,7 +8,8 @@ import Pagination from './Pagination';
 export default function EditableTable({
   columns = [],
   data = [],
-  setData = noop,
+  primaryKey = 'id',
+  setChangedData = noop,
   className,
   pagination,
   table = '',
@@ -75,7 +76,13 @@ export default function EditableTable({
             sortColumn={sortColumn}
             setSortColumn={setSortColumn}
           />
-          <EditableTableBody columns={columns} data={data} setData={setData} setEditing={setEditing} />
+          <EditableTableBody
+            columns={columns}
+            data={data}
+            setEditing={setEditing}
+            setChangedData={setChangedData}
+            primaryKey={primaryKey}
+          />
         </table>
       </div>
 


### PR DESCRIPTION
# Comits 
- REFECTOR: editable table refactor + performance additions

# Changes
added setChangedData wich externs only changed data to a useState on a formated object 
added a function to Treat data,
 - How to Use:  put all required adata treatments, like money or float point or other things to this function and declare it on the column where it should be applyed
added primaryKey, wich informs to table what to use as primarykey on objects 
Table no longer change originalData, 
 - Reason: this allow in case of bad request, to return table to originalState without needing to fetch again

# Pending updates
 - Visual improviments
 - Route / fetch on data change
 - save data button visibility

